### PR TITLE
Delete empty output files on error

### DIFF
--- a/pypi-trends.py
+++ b/pypi-trends.py
@@ -131,8 +131,9 @@ if __name__ == "__main__":
             exitcode, output = subprocess.getstatusoutput(cmd)
             if exitcode != 0:
                 print(output)
+                if os.path.getsize(outfile) == 0:
+                    os.remove(outfile)
                 sys.exit(exitcode)
-                # TODO write output to outfile only if exitcode is good
 
 
 # End of file


### PR DESCRIPTION
If there's an error from pypinfo, such as being out of quota (see below) or project not found during timespan, then delete the empty output JSON file.

```
Traceback (most recent call last):
  File "/usr/local/bin/pypinfo", line 11, in <module>
    load_entry_point('pypinfo', 'console_scripts', 'pypinfo')()
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 1043, in invoke
    return Command.invoke(self, ctx)
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/hugo/github/pypinfo/pypinfo/cli.py", line 150, in pypinfo
    query_rows = query_job.result(timeout=timeout // 1000)
  File "/usr/local/lib/python3.7/site-packages/google/cloud/bigquery/job.py", line 2501, in result
    super(QueryJob, self).result(timeout=timeout)
  File "/usr/local/lib/python3.7/site-packages/google/cloud/bigquery/job.py", line 672, in result
    return super(_AsyncJob, self).result(timeout=timeout)
  File "/usr/local/lib/python3.7/site-packages/google/api_core/future/polling.py", line 115, in result
    self._blocking_poll(timeout=timeout)
  File "/usr/local/lib/python3.7/site-packages/google/cloud/bigquery/job.py", line 2475, in _blocking_poll
    super(QueryJob, self)._blocking_poll(timeout=timeout)
  File "/usr/local/lib/python3.7/site-packages/google/api_core/future/polling.py", line 94, in _blocking_poll
    retry_(self._done_or_raise)()
  File "/usr/local/lib/python3.7/site-packages/google/api_core/retry.py", line 260, in retry_wrapped_func
    on_error=on_error,
  File "/usr/local/lib/python3.7/site-packages/google/api_core/retry.py", line 177, in retry_target
    return target()
  File "/usr/local/lib/python3.7/site-packages/google/api_core/future/polling.py", line 73, in _done_or_raise
    if not self.done():
  File "/usr/local/lib/python3.7/site-packages/google/cloud/bigquery/job.py", line 2463, in done
    location=self.location)
  File "/usr/local/lib/python3.7/site-packages/google/cloud/bigquery/client.py", line 560, in _get_query_results
    retry, method='GET', path=path, query_params=extra_params)
  File "/usr/local/lib/python3.7/site-packages/google/cloud/bigquery/client.py", line 315, in _call_api
    return call()
  File "/usr/local/lib/python3.7/site-packages/google/api_core/retry.py", line 260, in retry_wrapped_func
    on_error=on_error,
  File "/usr/local/lib/python3.7/site-packages/google/api_core/retry.py", line 177, in retry_target
    return target()
  File "/usr/local/lib/python3.7/site-packages/google/cloud/_http.py", line 293, in api_request
    raise exceptions.from_http_response(response)
google.api_core.exceptions.Forbidden: 403 GET https://www.googleapis.com/bigquery/v2/projects/pypinfo-hugovk/queries/fca9ef6d-f6ce-43e1-809d-990a4d08da9a?maxResults=0&timeoutMs=10000: Quota exceeded: Your project exceeded quota for free query bytes scanned. For more information, see https://cloud.google.com/bigquery/troubleshooting-errors
```