### PR TITLE
Add pypistats

### DIFF
--- a/jsons2csv.py
+++ b/jsons2csv.py
@@ -159,10 +159,20 @@ if __name__ == "__main__":
             d = json.load(json_data)
             # pprint(d)
             month_data = {"yyyy-mm": month_name}
-            for row in d["rows"]:
+            try:
+                # pypinfo
+                rows = d["rows"]
+                version_index = "python_version"
+                downloads_index = "download_count"
+            except KeyError:
+                # pypistats
+                rows = d["data"]
+                version_index = "category"
+                downloads_index = "downloads"
+            for row in rows:
                 # month_data[row["python_version"]] = float(row["percent"]) * 100
-                month_data[row["python_version"]] = row["download_count"]
-                all_versions.add(row["python_version"])
+                month_data[row[version_index]] = row[downloads_index]
+                all_versions.add(row[version_index])
         all_data.append(month_data)
 
     # pprint(all_data)

--- a/pypi-trends.py
+++ b/pypi-trends.py
@@ -8,6 +8,10 @@ For a given project, or all projects:
 Requires pypinfo to be installed and configured
 * https://github.com/ofek/pypinfo
 
+Alternatively, requires pypistats to be installed
+(note: only has 6 months of stats and output JSON is a different format)
+* pip install -U pypistats
+
 Notes:
     "Data ingestion into the BigQuery data set was spotty prior to June 2016
     (but it shouldn't be biased, so these percentages are likely to be accurate),
@@ -80,7 +84,14 @@ if __name__ == "__main__":
         "-t", "--to", dest="to_date", default=default_end_date(), help="End YYYY-MM"
     )
     parser.add_argument(
-        "-n", "--dry-run", action="store_true", help="Don't execute pypinfo"
+        "-n", "--dry-run", action="store_true", help="Don't execute pypinfo/pypistats"
+    )
+    parser.add_argument(
+        "--pypistats",
+        action="store_true",
+        help="Use pypistats instead of pypinfo. Note: only has "
+        "6 months of stats, and output JSON is a different "
+        "format.",
     )
     args = parser.parse_args()
 
@@ -114,17 +125,22 @@ if __name__ == "__main__":
             print(f"  {outfile} exists, skipping")
             continue
 
-        cmd = (
-            f"pypinfo --start-date {first} --end-date {last} --percent --limit 100 "
-            f"--json {args.package} pyversion > {outfile}"
-        )
-        # --start-date 2018-03-01 --end-date 2018-03-31 --limit 100
-        # --percent --json "" pyversion > 2018-03.json
+        if args.pypistats:
+            cmd = (
+                f"pypistats python_minor {args.package} --json "
+                f"--start-date {first} --end-date {last} > {outfile}"
+            )
+        else:
+            cmd = (
+                f"pypinfo --start-date {first} --end-date {last} --percent --limit 100 "
+                f"--json {args.package} pyversion > {outfile}"
+            )
 
         print(cmd)
         print()
+        executable = "pypistats" if args.pypistats else "pypinfo"
         if args.dry_run:
-            print("  Dry run, not executing pypinfo")
+            print(f"  Dry run, not executing {executable}")
         else:
             # os.system(cmd)
             exitcode, output = subprocess.getstatusoutput(cmd)


### PR DESCRIPTION
* `pypi-trends.py --pypistats` will use `pypistats` to get data instead of `pypistats`
   * Pro: Don't need to configure BigQuery with `pypinfo` 
   * Pro: Don't need to worry about BigQuery quota for `pypinfo` 
   * Con: Stats only available for the past 6 months
   * Con: JSON format of `pypistats` is slightly different to `pypinfo`

* Update `jsons2csv.py` to be able to read in JSON data from either `pypinfo` or `pypistats`

`pypinfo` output (prettified):
```json
{
  "last_update": "2018-10-01 07:43:19", 
  "query": {
    "bytes_billed": 40791703552, 
    "bytes_processed": 40790964510, 
    "cached": false, 
    "estimated_cost": "0.19"
  }, 
  "rows": [
    {
      "download_count": 1491518, 
      "percent": "0.47", 
      "python_version": "2.7"
    }, 
...
    {
      "download_count": 18, 
      "percent": "5.7e-06", 
      "python_version": "None"
    }
  ]
}
```


`pypistats` output (prettified):
```json
{
  "data": [
    {
      "category": "2.6", 
      "downloads": 287
    }, 
...
    {
      "category": "null", 
      "downloads": 24816
    }
  ], 
  "package": "matplotlib", 
  "type": "python_minor_downloads"
}
```

# TODO

* [ ] Trigger CI build when https://blog.github.com/2018-10-21-october21-incident-report/ is fixed
