### PR TITLE
Add repo_checker.py

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v1.25.3
+    rev: v1.26.1
     hooks:
       - id: pyupgrade
         args: ["--py36-plus"]
@@ -9,6 +9,7 @@ repos:
     rev: 19.10b0
     hooks:
       - id: black
+        args: ["--target-version", "py36"]
         # override until resolved: https://github.com/psf/black/issues/402
         files: \.pyi?$
         types: []
@@ -17,7 +18,7 @@ repos:
     rev: 3.7.9
     hooks:
       - id: flake8
-        additional_dependencies: [flake8-2020]
+        additional_dependencies: [flake8-2020, flake8-implicit-str-concat]
 
   - repo: https://github.com/asottile/seed-isort-config
     rev: v1.9.4
@@ -31,7 +32,7 @@ repos:
         additional_dependencies: [toml]
 
   - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.4.3
+    rev: v1.4.4
     hooks:
       - id: python-check-blanket-noqa
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.black]
-py36 = true
+target_version = ["py36"]
 
 [tool.isort]
 force_grid_wrap = 0

--- a/repo_checker.py
+++ b/repo_checker.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-TODO
+Tool to clone repos of popular projects, and run a test command for each.
 
 open list of top repos
 open list of repo source
@@ -35,7 +35,7 @@ from termcolor import colored  # pip install termcolor
 
 from top_repos import get_top_packages, load_from_file
 
-CLONE_ROOT = Path.home() / "repo_checker"
+CLONE_ROOT = Path.home() / "checked_repos"
 DEFAULT_CMD = f"flake8 --exclude six.py --extend-ignore C90 --select YTT1 CLONE_DIR"
 
 
@@ -82,7 +82,6 @@ def main():
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
-    # parser.add_argument("package", help="Package")
     parser.add_argument(
         "-n", "--number", type=int, default=10, help="Max number to check"
     )

--- a/repo_checker.py
+++ b/repo_checker.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""
+TODO
+
+open list of top repos
+open list of repo source
+for repo in repos:
+    git clone --depth 1 repo_git
+    cd repo
+    run custom command eg. flake8 --select YTT
+    if error, stop (TODO option to keep going)
+    TODO option to delete dir
+
+Example usage:
+
+Start by:
+
+# Fetch fresh copy of top packages
+wget https://hugovk.github.io/top-pypi-packages/top-pypi-packages-30-days.min.json -O \
+    data/top-pypi-packages.json
+
+$ python3 repo_checker.py
+$ python3 repo_checker.py --number 10
+$ python3 repo_checker.py --number 10 --skip-existing
+$ python3 repo_checker.py --number 10 --command "git -C CLONE_DIR pull"
+$ python3 repo_checker.py --number 10 -c "flake8 --select XYZ CLONE_DIR" --repos "foo"
+"""
+import argparse
+import os
+import subprocess
+from pathlib import Path
+from pprint import pprint  # noqa: F401
+
+from termcolor import colored  # pip install termcolor
+
+from top_repos import get_top_packages, load_from_file
+
+CLONE_ROOT = Path.home() / "repo_checker"
+DEFAULT_CMD = f"flake8 --exclude six.py --extend-ignore C90 --select YTT1 CLONE_DIR"
+
+
+def create_dir(directory):
+    if not os.path.isdir(directory):
+        os.mkdir(directory)
+
+
+def recursive_find(inspec):
+    import fnmatch
+    import os
+
+    matches = []
+    head, tail = os.path.split(inspec)
+    if len(head) == 0:
+        head = "."
+
+    for root, dirnames, filenames in os.walk(head):
+        for filename in fnmatch.filter(filenames, tail):
+            matches.append(os.path.join(root, filename))
+
+    return matches
+
+
+def do_cmd(cmd, check_return=True):
+    print(cmd)
+    result = subprocess.run(cmd.split())
+    colour = "green" if result.returncode == 0 else "red"
+    print(colored(f"  return code: {result.returncode}", colour))
+    if check_return:
+        result.check_returncode()
+
+
+def repo_url_dir_name(url):
+    """Like the Linux command: basename url ".git" """
+    url = url.rstrip("/")
+    if url.endswith(".git"):
+        url = url[:-4]
+    url = url.split("/")[-1]
+    return url
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    # parser.add_argument("package", help="Package")
+    parser.add_argument(
+        "-n", "--number", type=int, default=10, help="Max number to check"
+    )
+    parser.add_argument(
+        "-c",
+        "--command",
+        default=DEFAULT_CMD,
+        help='Command to run to test a repo. "CLONE_DIR" will be filled in.',
+    )
+    parser.add_argument(
+        "-r", "--repos", nargs="+", help="Skip these repos",
+    )
+    parser.add_argument(
+        "-s",
+        "--skip-existing",
+        action="store_true",
+        help="Don't test existing cloned repos",
+    )
+    parser.add_argument(
+        "--ignore-error",
+        action="store_true",
+        help="Continue to next repo, even if the command returned an error",
+    )
+    args = parser.parse_args()
+
+    # Load packages from top-pypi-packages.json
+    packages_todo = get_top_packages()
+    if args.number:
+        packages_todo = packages_todo[: args.number]
+
+    # Load repos from data/top-repos.json
+    package_repos = load_from_file("data/top-repos.json", "data")
+
+    repos = {}
+    for package_repo in package_repos:
+        repos[package_repo["name"]] = package_repo["repo"]
+
+    create_dir(CLONE_ROOT)
+
+    for i, package in enumerate(packages_todo):
+        name = package["name"]
+        try:
+            repo_url = repos[name]
+            print(i + 1, colored(f"{name} {repo_url}", "green"))
+        except KeyError:
+            print(i + 1, colored(f"{name} repo not found", "yellow"))
+            continue
+
+        clone_dir = CLONE_ROOT / repo_url_dir_name(repo_url)
+
+        # Skip cloning these
+        if name in [
+            "aenum",  # Hg
+            "backports-ssl-match-hostname",  # Hg
+            "enum34",  # Hg
+            "et-xmlfile",  # Hg
+            "iso8601",  # Hg
+            "openpyxl",  # Hg
+            "pbr",  # redirect not a repo
+            "ruamel-yaml",  # Hg
+            "ruamel-yaml-clib",  # Hg
+        ]:
+            print(colored("  Skipping Hg and uncloneable links", "yellow"))
+            continue
+        elif os.path.isdir(clone_dir):
+            if args.skip_existing:
+                print(colored("  Repo exists, skipping", "yellow"))
+                continue
+        else:
+            cmd = f"git clone --depth 1 {repo_url} {clone_dir}"
+            do_cmd(cmd)
+
+        # Skip scanning these
+        if name in args.repos:
+            continue
+
+        cmd = f"{args.command}"
+        cmd = cmd.replace("CLONE_DIR", str(clone_dir))
+        do_cmd(cmd, not args.ignore_error)
+
+
+if __name__ == "__main__":
+    main()
+
+# End of file

--- a/tests/test_repo_checker.py
+++ b/tests/test_repo_checker.py
@@ -1,0 +1,25 @@
+import pytest
+
+import repo_checker
+
+
+@pytest.mark.parametrize(
+    "test_input",
+    [
+        "http://github.com/octocat/Hello-World",
+        "http://github.com/octocat/Hello-World/",
+        "https://github.com/octocat/Hello-World",
+        "https://github.com/octocat/Hello-World.git",
+        "https://github.com/octocat/Hello-World.git",
+        "https://github.com/octocat/Hello-World/",
+    ],
+)
+def test_repo_url_dir_name(test_input):
+    # Arrange
+    repo_url = test_input
+
+    # Act
+    dir_name = repo_checker.repo_url_dir_name(repo_url)
+
+    # Assert
+    assert dir_name == "Hello-World"


### PR DESCRIPTION
Add a tool to clone repos of popular projects, and run a test command for each. Stops when found a problem.

The default command is `flake8 --select YTT1` to find potential Python 3.10 problems with https://github.com/asottile/flake8-2020.

Run on top 10 projects, will stop if the test command has a non-zero exit:

```sh
python3 repo_checker.py --number 10
```

Same, but if there's already an existing directory for a repo, it won't test that one again:

```sh
python3 repo_checker.py --number 10 --skip-existing
```

Using a custom command, `CLONE_DIR` will be replaced with the cloned directory. Here, will do a `git pull` in that repo to update:

```sh
python3 repo_checker.py --number 10 --command "git -C CLONE_DIR pull"
```

Custom command, will run for all repos, even if dirs exist, but will skip dirs "foo" and "bar".

```sh
python3 repo_checker.py --number 10 -c "flake8 --select XYZ CLONE_DIR" --repos foo bar
```
