### PR TITLE
Add script to summarise project_urls metadata

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,16 +14,16 @@ repos:
         files: \.pyi?$
         types: []
 
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.5.3
+    hooks:
+      - id: isort
+
   - repo: https://gitlab.com/pycqa/flake8
     rev: 3.8.3
     hooks:
       - id: flake8
         additional_dependencies: [flake8-2020, flake8-implicit-str-concat]
-
-  - repo: https://github.com/timothycrosley/isort
-    rev: 5.4.2
-    hooks:
-      - id: isort
 
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.6.0
@@ -38,3 +38,4 @@ repos:
       - id: check-toml
       - id: check-yaml
       - id: requirements-txt-fixer
+      - id: trailing-whitespace

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,13 @@ script:
   # Unit tests
   - python -m pytest
 
+  # Fetch fresh copy of top packages
+  - wget https://hugovk.github.io/top-pypi-packages/top-pypi-packages-30-days.min.json -O data/top-pypi-packages.json
+
   # Test run
   - python pypi-trends.py --dry-run
   - if [ "$TRAVIS_PYTHON_VERSION" != "3.9-dev" ]; then python jsons2csv.py ; fi
   - make -j4
   - python generate_readme.py
   - python macos-versions.py -i macos.json
+  - python project_urls.py -n 1

--- a/project_urls.py
+++ b/project_urls.py
@@ -1,0 +1,80 @@
+"""
+Read in packages from top-pypi-packages.json and fetch their project_urls metadata.
+
+(Metadata is cached by source_finder.py in CACHE_DIR.)
+
+Return a count of the most common keys.
+
+Start by:
+
+# Fetch fresh copy of top packages
+wget https://hugovk.github.io/top-pypi-packages/top-pypi-packages-30-days.min.json -O \
+    data/top-pypi-packages.json
+
+# Check the first 10 packages in data/top-pypi-packages.json
+python3 project_urls.py --number 10
+Load data/top-pypi-packages.json...
+Find project_urls...
+100%|█████████████████████████████████████████████| 10/10 [00:00<00:00, 167.91project/s]
+Counter({'Homepage': 10,
+         'Documentation': 4,
+         'Source': 2,
+         'Code': 1,
+         'Issue tracker': 1})
+
+Number with project_urls: 10/10
+"""
+import argparse
+import collections
+from pprint import pprint  # noqa: F401
+
+import httpx
+from tqdm import tqdm
+
+from source_finder import pypi_json
+from top_repos import get_top_packages
+
+
+def get_project_urls(package):
+    try:
+        res = pypi_json(package)
+        return res["info"]["project_urls"]
+    except httpx.HTTPStatusError:
+        # e.g. https://pypi.org/project/pprint/ has been removed
+        return None
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument(
+        "-n", "--number", type=int, default=100, help="Max number to fetch"
+    )
+    args = parser.parse_args()
+
+    # Load from top-pypi-packages.json
+    packages_todo = get_top_packages()
+    if args.number:
+        packages_todo = packages_todo[: args.number]
+
+    print("Find project_urls...")
+
+    all_keys = []
+    count = 0
+    for package in tqdm(packages_todo, unit="project"):
+        project_urls = get_project_urls(package["name"])
+        if project_urls:
+            all_keys.extend(project_urls.keys())
+            count += 1
+
+    # Counter will sort by most common, but let's sort alphabetically
+    # for those with the same count
+    all_keys = sorted(all_keys)
+    pprint(collections.Counter(all_keys))
+    print()
+    print(f"Number with project_urls: {count}/{args.number}")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,9 +2,4 @@
 target_version = ["py36"]
 
 [tool.isort]
-force_grid_wrap = 0
-include_trailing_comma = true
-known_third_party = ["appdirs", "dateutil", "httpx", "natsort", "packaging", "pypidb", "pytablewriter", "pytest", "pytz", "requests", "slugify", "termcolor"]
-line_length = 88
-multi_line_output = 3
-use_parentheses = true
+profile = "black"

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ python-dateutil
 python-slugify
 pytz
 termcolor
+tqdm


### PR DESCRIPTION
Metadata for current top 4,000:

```console
$ python3 project_urls.py -n 4000
Load data/top-pypi-packages.json...
Find project_urls...
100%|████████████████████████████████| 4000/4000 [00:07<00:00, 524.71project/s]
Counter({'Homepage': 3916,
         'Download': 778,
         'Documentation': 240,
         'Source': 152,
         'Changelog': 70,
         'Repository': 63,
         'Bug Tracker': 62,
         'Source Code': 60,
         'Tracker': 55,
         'Issue tracker': 39,
         'Issue Tracker': 30,
         'GitHub': 28,
         'Code': 26,
         'Issues': 21,
         'Funding': 20,
         'Bug Reports': 17,
         'Bug-Tracker': 8,
         'Twitter': 8,
         'CI: Travis': 7,
         'Source-Code': 7,
         'Docs': 6,
         'GitHub: issues': 6,
         'GitHub: repo': 6,
         'Github': 6,
         'Source code': 6,
         'bugs': 6,
         'repository': 6,
         'Docs: RTD': 5,
         'Donation': 5,
         'CI: AppVeyor': 3,
         'CI: Circle': 3,
         'Chat: Gitter': 3,
         'Code of Conduct': 3,
         'Coverage: codecov': 3,
         'Donate': 3,
         'Mailing List': 3,
         'Say Thanks!': 3,
         'Tidelift': 3,
         'Travis CI': 3,
         'CI': 2,
         'CI: GitHub': 2,
         'CI: Shippable': 2,
         'Change log': 2,
         'Chat': 2,
         'Download RPMs': 2,
         'Forum': 2,
         'Mailing lists': 2,
         'Release Management': 2,
         'Release notes': 2,
         'Tidelift: funding': 2,
         'Website': 2,
         'Benchmarks': 1,
         'Blog': 1,
         'Bug tracker': 1,
         'Bugs': 1,
         'CI: Azure Pipelines': 1,
         'CI: CircleCI': 1,
         'CI: GitHub Workflows': 1,
         'CI: Zuul': 1,
         'Code Coverage': 1,
         'Commercial License': 1,
         'Community': 1,
         'Conda-Forge': 1,
         'Continuous Integration': 1,
         'Coverage': 1,
         'Dev Docs': 1,
         'Discord': 1,
         'Discussions': 1,
         'Downloads': 1,
         'Examples': 1,
         'Feedstock': 1,
         'Further Documentation': 1,
         'Github repo': 1,
         'Help/Questions': 1,
         'History': 1,
         'License': 1,
         'Online Demo': 1,
         'Packaging tutorial': 1,
         'PyPI': 1,
         'Read the Docs': 1,
         'Release Notes': 1,
         'Releases': 1,
         'Support': 1,
         'Test Coverage': 1,
         'Tests': 1,
         'Tutorials': 1,
         'Twine documentation': 1,
         'Twine source': 1,
         "What's New": 1,
         'Wiki': 1,
         'Wikipedia': 1,
         'conda': 1})

Number with project_urls: 3925/4000
```