### PR TITLE
Add --key to also show project_urls with this key

### DIFF
--- a/project_urls.py
+++ b/project_urls.py
@@ -51,6 +51,7 @@ def main():
     parser.add_argument(
         "-n", "--number", type=int, default=100, help="Max number to fetch"
     )
+    parser.add_argument("-k", "--key", help="Also show project_urls with this key")
     args = parser.parse_args()
 
     # Load from top-pypi-packages.json
@@ -61,12 +62,18 @@ def main():
     print("Find project_urls...")
 
     all_keys = []
+    selected_urls = []
     count = 0
     for package in tqdm(packages_todo, unit="project"):
         project_urls = get_project_urls(package["name"])
         if project_urls:
             all_keys.extend(project_urls.keys())
             count += 1
+            if args.key:
+                try:
+                    selected_urls.append(project_urls[args.key])
+                except KeyError:
+                    pass
 
     # Counter will sort by most common, but let's sort alphabetically
     # for those with the same count
@@ -74,6 +81,11 @@ def main():
     pprint(collections.Counter(all_keys))
     print()
     print(f"Number with project_urls: {count}/{args.number}")
+
+    if args.key:
+        print()
+        print(f'All project_url["{args.key}"] values:')
+        print("\n* " + "\n* ".join(selected_urls))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
```console
$ python3 project_urls.py -k Documentation
Load data/top-pypi-packages.json...
Find project_urls...
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 100/100 [00:00<00:00, 271.94project/s]
Counter({'Homepage': 100,
         'Documentation': 20,
         'Download': 8,
         'Code': 7,
         'Issue tracker': 7,
         'Source': 6,
         'Bug Tracker': 4,
         'Source Code': 4,
         'Changelog': 2,
         'Funding': 2,
         'Issue Tracker': 2,
         'Docs': 1,
         'Issues': 1,
         'Tracker': 1})

Number with project_urls: 100/100

All project_url["Documentation"] values:

* https://urllib3.readthedocs.io/
* https://requests.readthedocs.io
* https://certifiio.readthedocs.io/en/latest/
* https://setuptools.readthedocs.io/
* https://pip.pypa.io
* https://numpy.org/doc/1.19
* https://wheel.readthedocs.io/
* https://markupsafe.palletsprojects.com/
* https://jinja.palletsprojects.com/
* https://www.attrs.org/
* https://click.palletsprojects.com/
* https://pandas.pydata.org/pandas-docs/stable/
* https://pillow.readthedocs.io
* https://werkzeug.palletsprojects.com/
* https://docs.scipy.org/doc/scipy/reference/
* https://docs.sqlalchemy.org
* https://flask.palletsprojects.com/
* https://www.python-httpx.org
* https://itsdangerous.palletsprojects.com/
* https://coverage.readthedocs.io
```