### PR TITLE
Fix parse("None") for packaging 22.0

### DIFF
--- a/jsons2csv.py
+++ b/jsons2csv.py
@@ -198,12 +198,12 @@ def load_data_from_json(inspec, quiet=True):
                 downloads_index = "downloads"
             for row in rows:
                 version = row[version_index]
-                base_version = parse(version).base_version  # strips a4, b2, rc1
 
                 # Skip unknown versions
-                if version in ["None", "null", "Sure.0"]:
+                if version in ("None", "null", "Sure.0"):
                     continue
 
+                base_version = parse(version).base_version  # strips a4, b2, rc1
                 # month_data[row["python_version"]] = float(row["percent"]) * 100
                 month_data[base_version] += row[downloads_index]
                 all_versions.add(base_version)


### PR DESCRIPTION
In the JSON we have some `"None"` version values:

```json
...
{
"download_count": 122870,
"percent": "0.00042",
"python_version": "3.6"
},
{
"download_count": 56248,
"percent": "0.00019",
"python_version": "None"
},
...
```

Packaging 22.0 removed `LegacyVersion`:

https://github.com/pypa/packaging/issues/530

This causes errors like this:

```pytb
$ python3 jsons2csv.py --chart --no-show -p tablib
data/tablib-2016-01.json 2016-01
Traceback (most recent call last):
  File "/Users/hugo/github/pypi-tools/jsons2csv.py", line 269, in <module>
    main()
  File "/Users/hugo/github/pypi-tools/jsons2csv.py", line 237, in main
    all_data, all_versions = load_data_from_json(args.inspec, args.quiet)
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hugo/github/pypi-tools/jsons2csv.py", line 201, in load_data_from_json
    base_version = parse(version).base_version  # strips a4, b2, rc1
                   ^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/packaging/version.py", line 52, in parse
    return Version(version)
           ^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/packaging/version.py", line 197, in __init__
    raise InvalidVersion(f"Invalid version: '{version}'")
packaging.version.InvalidVersion: Invalid version: 'None'
```

Minimal reproducer with last working version, packaging 21.3, shows `parse("None")` returns a `LegacyVersion`:

```pycon
>>> from packaging.version import parse
>>> parse("1.0")
<Version('1.0')>
>>> parse("None")
<LegacyVersion('None')>
```

Well, we're skipping `"None"` and some other unknowns on the very next line, so it's a simple fix to skip before the redundant parse.